### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,8 +349,8 @@ AFRAME.registerShader('html', {
     log('__draw')
     if (!this.__ctx || !this.__texture) { return }
     const ratio = canvas.width / canvas.height
-    const cnvW = this.__cnv.width = THREE.Math.nearestPowerOfTwo(canvas.width)
-    const cnvH = this.__cnv.height = THREE.Math.nearestPowerOfTwo(canvas.height)
+    const cnvW = this.__cnv.width = THREE.Math.floorPowerOfTwo(canvas.width)
+    const cnvH = this.__cnv.height = THREE.Math.floorPowerOfTwo(canvas.height)
     this.__ctx.drawImage(canvas, 0, 0, cnvW, cnvH)
     this.__texture.needsUpdate = true
     if (this.__ratio) {


### PR DESCRIPTION
removes the warning that aframe shows when using this plugin (function has changed names in the underlying three.js)